### PR TITLE
fix linker flag bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,8 @@ ${PROJECT}: main.o ${OBJS}
 	${CC} -o $@ main.o ${OBJS} ${LDFLAGS}
 
 test_${PROJECT}: test_${PROJECT}.o ${TEST_OBJS}
-	${CC} -o $@ test_${PROJECT}.o ${TEST_LDFLAGS} \
-		${TEST_OBJS} ${TEST_CFLAGS}
+	${CC} -o $@ test_${PROJECT}.o  \
+		${TEST_OBJS} ${TEST_CFLAGS} ${TEST_LDFLAGS}
 
 test: ./test_${PROJECT}
 	./test_${PROJECT}


### PR DESCRIPTION
The LDFLAGS have to be last in line, otherwise this yields linker errors for the tests